### PR TITLE
Add matrix strategy for Rust versions in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,40 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        rust: [1.83.0, stable]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+
+      - name: Build
+        run: cargo build --verbose
+
+      - name: Run tests
+        run: cargo test --verbose
+        
+      - name: Check formatting
+        run: cargo fmt -- --check
+        if: matrix.rust == 'stable'
+        
+      - name: Clippy
+        run: cargo clippy
+        if: matrix.rust == 'stable'


### PR DESCRIPTION
Added a matrix strategy to run builds and tests on multiple Rust versions,'1.83.0' and 'stable'. Included steps for formatting checks and Clippy analysis for the stable version.