### PR TITLE
feat: wire Rust checker into main with inline suppression support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,13 @@
 pub mod python;
 pub mod rust;
-pub use python::checker::check_file_for_docstrings;
-// pub use rust::checker::run;
+pub use python::checker::check_file_for_docstrings as check_python_file;
+pub use rust::checker::check_file_for_docstrings as check_rust_file;
 pub mod utils;
+
+pub enum Language {
+    Python,
+    Rust,
+}
 
 #[derive(PartialEq, Debug)]
 pub struct MissingDocstring {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use anyhow::Error;
 use colored::Colorize;
-use docstring_guard::{check_file_for_docstrings, MissingDocstring};
+use docstring_guard::{check_python_file, check_rust_file, MissingDocstring};
+use std::path::Path;
 use std::process::exit;
 use std::{collections::HashSet, env};
 
@@ -11,12 +12,20 @@ fn main() {
     let mut fails: HashSet<String> = HashSet::new();
 
     for argv in &args {
-        match check_file_for_docstrings(argv) {
-            Ok(missing_docstrings) => {
-                docstring_fails.extend(missing_docstrings);
-            }
-            Err(err) => {
-                errors.push(err);
+        let path = Path::new(argv);
+        if let Some(extension) = path.extension() {
+            let result: Result<Vec<MissingDocstring>, Error> = match extension.to_str() {
+                Some("py") => check_python_file(path),
+                Some("rs") => check_rust_file(path),
+                _ => continue,
+            };
+            match result {
+                Ok(missing_docstrings) => {
+                    docstring_fails.extend(missing_docstrings);
+                }
+                Err(err) => {
+                    errors.push(err);
+                }
             }
         }
     }
@@ -52,6 +61,5 @@ fn main() {
         );
         exit(1)
     }
-
     exit(0)
 }

--- a/src/python/checker.rs
+++ b/src/python/checker.rs
@@ -1,10 +1,5 @@
 use super::documentable::Documentable;
-use crate::{
-    utils::{
-        ignore_validation, load_file_content, load_file_error_formating, parse_error_formating,
-    },
-    MissingDocstring,
-};
+use crate::{utils, Language, MissingDocstring};
 
 use anyhow::{Context, Result};
 use rustpython_parser::{ast::Stmt, parse, text_size::TextRange, Mode};
@@ -65,7 +60,7 @@ fn check_documentable_for_docstring(
     let id = stmt.name().as_str();
     let line_number = get_line_number(content, range);
 
-    if !is_dunder(id) && !ignore_validation(line_number, content) {
+    if !is_dunder(id) && !utils::ignore_validation(Language::Python, line_number, content) {
         if let Some(docstring) = stmt.body().first() {
             if !is_docstring(docstring) {
                 let entry = MissingDocstring {
@@ -82,9 +77,10 @@ fn check_documentable_for_docstring(
 
 pub fn check_file_for_docstrings(file_path: impl AsRef<Path>) -> Result<Vec<MissingDocstring>> {
     let path = file_path.as_ref();
-    let content = load_file_content(path).with_context(|| load_file_error_formating(path))?;
-    let module: rustpython_parser::ast::Mod =
-        parse(&content, Mode::Module, "<unknown>").with_context(|| parse_error_formating(path))?;
+    let content =
+        utils::load_file_content(path).with_context(|| utils::load_file_error_formating(path))?;
+    let module: rustpython_parser::ast::Mod = parse(&content, Mode::Module, "<unknown>")
+        .with_context(|| utils::parse_error_formating(path))?;
 
     let mut missing_docstrings: Vec<MissingDocstring> = vec![];
     if let Some(module) = &module.as_module() {
@@ -184,6 +180,9 @@ mod tests {
         #[case] line_number: usize,
         #[case] expected: bool,
     ) {
-        assert_eq!(expected, ignore_validation(line_number, &input));
+        assert_eq!(
+            expected,
+            utils::ignore_validation(Language::Python, line_number, &input)
+        );
     }
 }

--- a/src/rust/checker.rs
+++ b/src/rust/checker.rs
@@ -1,41 +1,51 @@
 use super::documentable::Documentable;
-use crate::{
-    utils::{load_file_content, load_file_error_formating, parse_error_formating},
-    MissingDocstring,
-};
+use crate::{utils, Language, MissingDocstring};
 
 use anyhow::{Context, Result};
 use std::path::Path;
 use syn::visit::{self, Visit};
 use syn::{ItemFn, ItemStruct, Visibility};
 
-struct DocstringVisitor {
+struct DocstringVisitor<'a> {
     file_name: String,
     missing_docstrings: Vec<MissingDocstring>,
+    file_content: &'a str,
 }
 
-impl<'ast> Visit<'ast> for DocstringVisitor {
+impl<'ast> Visit<'ast> for DocstringVisitor<'_> {
     fn visit_item_fn(&mut self, i: &'ast ItemFn) {
-        if let Some(missing_docstring) = has_docstring(&self.file_name, i) {
-            self.missing_docstrings.push(missing_docstring)
+        if !utils::ignore_validation(
+            Language::Rust,
+            i.sig.ident.span().start().line,
+            self.file_content,
+        ) {
+            if let Some(missing_docstring) = has_docstring(&self.file_name, i) {
+                self.missing_docstrings.push(missing_docstring)
+            }
         }
         visit::visit_item_fn(self, i);
     }
 
     fn visit_item_struct(&mut self, i: &'ast ItemStruct) {
-        if let Some(missing_docstring) = has_docstring(&self.file_name, i) {
-            self.missing_docstrings.push(missing_docstring)
+        if !utils::ignore_validation(
+            Language::Rust,
+            i.ident.span().start().line,
+            self.file_content,
+        ) {
+            if let Some(missing_docstring) = has_docstring(&self.file_name, i) {
+                self.missing_docstrings.push(missing_docstring)
+            }
         }
         visit::visit_item_struct(self, i);
     }
 }
 
-fn has_docstring(file_name: &String, item: &impl Documentable) -> Option<MissingDocstring> {
+fn has_docstring(file_name: &str, item: &impl Documentable) -> Option<MissingDocstring> {
     match item.vis() {
         Visibility::Public(_) => {
             if !item.attrs().iter().any(|attr| attr.path().is_ident("doc")) {
                 let entry = MissingDocstring {
-                    file_name: file_name.clone(),
+                    file_name: file_name.to_owned(),
                     name: item.ident().to_string(),
                     line_number: item.ident().span().start().line,
                 };
@@ -49,13 +59,15 @@ fn has_docstring(file_name: &String, item: &impl Documentable) -> Option<Missing
 
 pub fn check_file_for_docstrings(file_path: impl AsRef<Path>) -> Result<Vec<MissingDocstring>> {
     let path = file_path.as_ref();
-    let content = load_file_content(path).with_context(|| load_file_error_formating(path))?;
+    let content =
+        utils::load_file_content(path).with_context(|| utils::load_file_error_formating(path))?;
 
-    let ast = syn::parse_file(&content).with_context(|| parse_error_formating(path))?;
+    let ast = syn::parse_file(&content).with_context(|| utils::parse_error_formating(path))?;
 
     let mut visitor = DocstringVisitor {
         file_name: path.display().to_string(),
         missing_docstrings: Vec::new(),
+        file_content: &content,
     };
     visitor.visit_file(&ast);
 

--- a/src/rust/tests/fixtures/test_documented_fn.rs
+++ b/src/rust/tests/fixtures/test_documented_fn.rs
@@ -7,3 +7,8 @@ pub fn documented_function() {
 pub fn outer_doc_function() {
     println!("no doc comment here");
 }
+
+#[rustfmt::skip]
+pub fn ignore_this_function() { //docstring-guard=ignore
+    println!("this function is ignored");
+}

--- a/src/rust/tests/fixtures/test_documented_struct.rs
+++ b/src/rust/tests/fixtures/test_documented_struct.rs
@@ -2,3 +2,8 @@
 pub struct DocumentedStruct {
     name: String,
 }
+
+#[rustfmt::skip]
+pub struct IgnoredStruct { //docstring-guard=ignore
+    name: String,
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,6 +2,8 @@ use anyhow::Result;
 use colored::Colorize;
 use std::{fs, path::Path};
 
+use crate::Language;
+
 pub fn load_file_content(path: impl AsRef<Path>) -> Result<String> {
     fs::read_to_string(path.as_ref()).map_err(anyhow::Error::from)
 }
@@ -26,10 +28,14 @@ fn remove_whitespace(s: &str) -> String {
     s.chars().filter(|c| !c.is_whitespace()).collect()
 }
 
-pub fn ignore_validation(line_number: usize, content: &str) -> bool {
+pub fn ignore_validation(lang: Language, line_number: usize, content: &str) -> bool {
     let mut lines = content.lines();
     if let Some(ignore) = lines.nth(line_number - 1) {
-        return remove_whitespace(ignore).contains("#docstring-guard=ignore");
+        let prefix = match lang {
+            Language::Python => "#",
+            Language::Rust => "//",
+        };
+        return remove_whitespace(ignore).contains(&format!("{}docstring-guard=ignore", prefix));
     }
     false
 }


### PR DESCRIPTION
Wire into main.rs with extension-based routing alongside existing Python checker. Extend ignore_validation in utils.rs to support language-specific comment prefixes via Language enum.

Note: inline suppression via //docstring-guard=ignore conflicts with rustfmt. Workaround uses #[rustfmt::skip] in fixtures. Attribute-based suppression planned for v0.2.0.