### PR TITLE
chore: semantically equivalent simplification + extra test cases

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub use python::checker::check_file_for_docstrings as check_python_file;
 pub use rust::checker::check_file_for_docstrings as check_rust_file;
 pub mod utils;
 
+#[derive(Clone, Copy)]
 pub enum Language {
     Python,
     Rust,

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,19 +13,23 @@ fn main() {
 
     for argv in &args {
         let path = Path::new(argv);
-        if let Some(extension) = path.extension() {
-            let result: Result<Vec<MissingDocstring>, Error> = match extension.to_str() {
-                Some("py") => check_python_file(path),
-                Some("rs") => check_rust_file(path),
-                _ => continue,
-            };
-            match result {
-                Ok(missing_docstrings) => {
-                    docstring_fails.extend(missing_docstrings);
-                }
-                Err(err) => {
-                    errors.push(err);
-                }
+
+        let Some(extension) = path.extension() else {
+            continue;
+        };
+
+        let result = match extension.to_str() {
+            Some("py") => check_python_file(path),
+            Some("rs") => check_rust_file(path),
+            _ => continue,
+        };
+
+        match result {
+            Ok(missing_docstrings) => {
+                docstring_fails.extend(missing_docstrings);
+            }
+            Err(err) => {
+                errors.push(err);
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,11 +34,11 @@ fn main() {
         }
     }
 
-    for err in errors.iter() {
+    for err in &errors {
         eprintln!("{} - {}", err, err.root_cause());
     }
 
-    for missing_docstring in docstring_fails.iter() {
+    for missing_docstring in &docstring_fails {
         println!(
             "{} {} no docstring in '{}'",
             format!(

--- a/src/python/checker.rs
+++ b/src/python/checker.rs
@@ -62,7 +62,7 @@ fn check_documentable_for_docstring(
     let id = stmt.name().as_str();
     let line_number = get_line_number(content, range);
 
-    if !is_dunder(id) && !utils::ignore_validation(&Language::Python, line_number, content) {
+    if !is_dunder(id) && !utils::ignore_validation(Language::Python, line_number, content) {
         if let Some(docstring) = stmt.body().first() {
             if !is_docstring(docstring) {
                 let entry = MissingDocstring {
@@ -186,7 +186,7 @@ mod tests {
     ) {
         assert_eq!(
             expected,
-            utils::ignore_validation(&Language::Python, line_number, &input)
+            utils::ignore_validation(Language::Python, line_number, &input)
         );
     }
 }

--- a/src/python/checker.rs
+++ b/src/python/checker.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 fn is_docstring(stmt: &Stmt) -> bool {
     stmt.as_expr_stmt()
         .and_then(|e| e.value.as_constant_expr())
-        .map_or(false, |c| c.value.is_str())
+        .is_some_and(|c| c.value.is_str())
 }
 
 fn is_dunder(name: &str) -> bool {

--- a/src/python/checker.rs
+++ b/src/python/checker.rs
@@ -40,9 +40,9 @@ fn check_statements_for_docstrings(
 ) -> Vec<MissingDocstring> {
     let mut missing_docstrings = vec![];
 
-    for stmt in stmts.iter() {
+    for stmt in stmts {
         if let Some(entry) = check_statement_for_docstring(path, content, stmt) {
-            missing_docstrings.push(entry)
+            missing_docstrings.push(entry);
         }
 
         if let Some(s) = stmt.as_class_def_stmt() {
@@ -62,7 +62,7 @@ fn check_documentable_for_docstring(
     let id = stmt.name().as_str();
     let line_number = get_line_number(content, range);
 
-    if !is_dunder(id) && !utils::ignore_validation(Language::Python, line_number, content) {
+    if !is_dunder(id) && !utils::ignore_validation(&Language::Python, line_number, content) {
         if let Some(docstring) = stmt.body().first() {
             if !is_docstring(docstring) {
                 let entry = MissingDocstring {
@@ -186,7 +186,7 @@ mod tests {
     ) {
         assert_eq!(
             expected,
-            utils::ignore_validation(Language::Python, line_number, &input)
+            utils::ignore_validation(&Language::Python, line_number, &input)
         );
     }
 }

--- a/src/python/checker.rs
+++ b/src/python/checker.rs
@@ -21,37 +21,42 @@ fn get_line_number(content: &str, range: TextRange) -> usize {
     slice.chars().filter(|c| *c == '\n').count() + 1
 }
 
+fn check_statement_for_docstring(
+    path: &Path,
+    content: &str,
+    stmt: &Stmt,
+) -> Option<MissingDocstring> {
+    match stmt {
+        Stmt::FunctionDef(s) => check_documentable_for_docstring(path, content, s),
+        Stmt::ClassDef(s) => check_documentable_for_docstring(path, content, s),
+        _ => None,
+    }
+}
+
 fn check_statements_for_docstrings(
     path: &Path,
     content: &str,
     stmts: &[Stmt],
 ) -> Vec<MissingDocstring> {
-    let mut missing_docstrings: Vec<MissingDocstring> = vec![];
+    let mut missing_docstrings = vec![];
 
     for stmt in stmts.iter() {
-        let entry: Option<MissingDocstring> = if let Some(s) = stmt.as_function_def_stmt() {
-            check_documentable_for_docstring(path, s, content)
-        } else if let Some(s) = stmt.as_class_def_stmt() {
-            if let Some(missing) = check_documentable_for_docstring(path, s, content) {
-                missing_docstrings.push(missing);
-            }
-            missing_docstrings.extend(check_statements_for_docstrings(path, content, s.body()));
-            continue;
-        } else {
-            None
-        };
+        if let Some(entry) = check_statement_for_docstring(path, content, stmt) {
+            missing_docstrings.push(entry)
+        }
 
-        if let Some(e) = entry {
-            missing_docstrings.push(e);
+        if let Some(s) = stmt.as_class_def_stmt() {
+            missing_docstrings.extend(check_statements_for_docstrings(path, content, s.body()));
         }
     }
+
     missing_docstrings
 }
 
 fn check_documentable_for_docstring(
     path: &Path,
-    stmt: &impl Documentable,
     content: &str,
+    stmt: &impl Documentable,
 ) -> Option<MissingDocstring> {
     let range = stmt.range();
     let id = stmt.name().as_str();

--- a/src/python/checker.rs
+++ b/src/python/checker.rs
@@ -12,10 +12,7 @@ fn is_docstring(stmt: &Stmt) -> bool {
 }
 
 fn is_dunder(name: &str) -> bool {
-    if name.starts_with("__") && name.ends_with("__") {
-        return true;
-    }
-    false
+    name.starts_with("__") && name.ends_with("__")
 }
 
 fn get_line_number(content: &str, range: TextRange) -> usize {
@@ -150,6 +147,8 @@ mod tests {
     #[case("__init__", true)]
     #[case("test", false)]
     #[case("_test", false)]
+    #[case("_test__", false)]
+    #[case("__test_", false)]
     fn test_is_dunder(#[case] input: String, #[case] expected: bool) {
         assert_eq!(expected, is_dunder(&input))
     }

--- a/src/rust/checker.rs
+++ b/src/rust/checker.rs
@@ -15,7 +15,7 @@ struct DocstringVisitor<'a> {
 impl<'ast> Visit<'ast> for DocstringVisitor<'_> {
     fn visit_item_fn(&mut self, i: &'ast ItemFn) {
         if !utils::ignore_validation(
-            &Language::Rust,
+            Language::Rust,
             i.sig.ident.span().start().line,
             self.file_content,
         ) {
@@ -28,7 +28,7 @@ impl<'ast> Visit<'ast> for DocstringVisitor<'_> {
 
     fn visit_item_struct(&mut self, i: &'ast ItemStruct) {
         if !utils::ignore_validation(
-            &Language::Rust,
+            Language::Rust,
             i.ident.span().start().line,
             self.file_content,
         ) {

--- a/src/rust/checker.rs
+++ b/src/rust/checker.rs
@@ -15,12 +15,12 @@ struct DocstringVisitor<'a> {
 impl<'ast> Visit<'ast> for DocstringVisitor<'_> {
     fn visit_item_fn(&mut self, i: &'ast ItemFn) {
         if !utils::ignore_validation(
-            Language::Rust,
+            &Language::Rust,
             i.sig.ident.span().start().line,
             self.file_content,
         ) {
             if let Some(missing_docstring) = has_docstring(&self.file_name, i) {
-                self.missing_docstrings.push(missing_docstring)
+                self.missing_docstrings.push(missing_docstring);
             }
         }
         visit::visit_item_fn(self, i);
@@ -28,12 +28,12 @@ impl<'ast> Visit<'ast> for DocstringVisitor<'_> {
 
     fn visit_item_struct(&mut self, i: &'ast ItemStruct) {
         if !utils::ignore_validation(
-            Language::Rust,
+            &Language::Rust,
             i.ident.span().start().line,
             self.file_content,
         ) {
             if let Some(missing_docstring) = has_docstring(&self.file_name, i) {
-                self.missing_docstrings.push(missing_docstring)
+                self.missing_docstrings.push(missing_docstring);
             }
         }
         visit::visit_item_struct(self, i);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -28,7 +28,7 @@ fn remove_whitespace(s: &str) -> String {
     s.chars().filter(|c| !c.is_whitespace()).collect()
 }
 
-pub fn ignore_validation(lang: &Language, line_number: usize, content: &str) -> bool {
+pub fn ignore_validation(lang: Language, line_number: usize, content: &str) -> bool {
     let mut lines = content.lines();
     if let Some(ignore) = lines.nth(line_number - 1) {
         let prefix = match lang {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -28,14 +28,14 @@ fn remove_whitespace(s: &str) -> String {
     s.chars().filter(|c| !c.is_whitespace()).collect()
 }
 
-pub fn ignore_validation(lang: Language, line_number: usize, content: &str) -> bool {
+pub fn ignore_validation(lang: &Language, line_number: usize, content: &str) -> bool {
     let mut lines = content.lines();
     if let Some(ignore) = lines.nth(line_number - 1) {
         let prefix = match lang {
             Language::Python => "#",
             Language::Rust => "//",
         };
-        return remove_whitespace(ignore).contains(&format!("{}docstring-guard=ignore", prefix));
+        return remove_whitespace(ignore).contains(&format!("{prefix}docstring-guard=ignore"));
     }
     false
 }


### PR DESCRIPTION
- Semantically equivalent simplification to improve readability
- 2 extra test cases since I discovered that changing the code to incorrect `name.starts_with("_") && name.ends_with("__")` in `is_dunder` slipped by tests
- clippy lint fixes (including some from clippy::pedantic)